### PR TITLE
LIB-106: fix by forcing logoutUrl to backend /logout and don’t mark session as Kratos

### DIFF
--- a/src/App/Layout/Navbar/index.tsx
+++ b/src/App/Layout/Navbar/index.tsx
@@ -25,17 +25,7 @@ const Navbar: FC<NavbarProps> = ({
 }) => {
   const handleLogout = () => {
     if (logoutUrl) {
-      if (kratos) {
-        fetch(logoutUrl, {
-          headers: { accept: 'application/json' },
-        })
-          .then((response) => response.json())
-          .then(({ logout_url }) => {
-            if (logout_url) window.location.assign(logout_url);
-          });
-      } else {
         window.location.href = logoutUrl;
-      }
     }
   };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -49,8 +49,8 @@ async function bootstrap() {
         givenName: userInfo.given_name,
         familyName: userInfo.family_name,
         email: userInfo.email,
-        kratos: userInfo.kratos,
-        logoutUrl: 'logoutUrl' in userInfo ? userInfo.logoutUrl : `${config.apiBaseUrl}/logout`,
+        kratos: false,
+        logoutUrl: `${config.apiBaseUrl}/logout`,
       };
 
       // only render if we got user info i.e. we are authenticated


### PR DESCRIPTION
Require exp api to have `ENABLE_AUTH_CLIENT : true` in env varialbles... so that auth middleware like `/logout` works.

The UI sometimes treated the deployment as Kratos-based and called Kratos’ browser-logout flow. That sent users to Keycloak’s confirm-logout UI and didn’t bounce back to our login page.

Fix: Always delegate logout to the exp api's (/logout), which performs RP-initiated logout against Keycloak